### PR TITLE
Build `ascii` feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,3 +78,7 @@ Style/WordArray:
 
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.12.0)
+    strscan (3.0.5)
     unicode-display_width (2.4.2)
 
 PLATFORMS
@@ -50,6 +51,7 @@ DEPENDENCIES
   rspec
   rubocop
   rubocop-rspec
+  strscan
 
 RUBY VERSION
    ruby 3.2.1p31

--- a/lib/ascii.rb
+++ b/lib/ascii.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+module GurmukhiUtils
+  ASCII_TRANSLATION = {
+    'ੳ'.ord => 'a',
+    'ਅ'.ord => 'A',
+    'ੲ'.ord => 'e',
+    'ਸ'.ord => 's',
+    'ਹ'.ord => 'h',
+    'ਕ'.ord => 'k',
+    'ਖ'.ord => 'K',
+    'ਗ'.ord => 'g',
+    'ਘ'.ord => 'G',
+    'ਙ'.ord => '|',
+    'ਚ'.ord => 'c',
+    'ਛ'.ord => 'C',
+    'ਜ'.ord => 'j',
+    'ਝ'.ord => 'J',
+    'ਞ'.ord => '\\',
+    'ਟ'.ord => 't',
+    'ਠ'.ord => 'T',
+    'ਡ'.ord => 'f',
+    'ਢ'.ord => 'F',
+    'ਣ'.ord => 'x',
+    'ਤ'.ord => 'q',
+    'ਥ'.ord => 'Q',
+    'ਦ'.ord => 'd',
+    'ਧ'.ord => 'D',
+    'ਨ'.ord => 'n',
+    'ਪ'.ord => 'p',
+    'ਫ'.ord => 'P',
+    'ਬ'.ord => 'b',
+    'ਭ'.ord => 'B',
+    'ਮ'.ord => 'm',
+    'ਯ'.ord => 'X',
+    'ਰ'.ord => 'r',
+    'ਲ'.ord => 'l',
+    'ਵ'.ord => 'v',
+    'ੜ'.ord => 'V',
+    'ਸ਼'.ord => 'S',
+    'ਜ਼'.ord => 'z',
+    'ਖ਼'.ord => '^',
+    'ਫ਼'.ord => '&',
+    'ਗ਼'.ord => 'Z',
+    'ਲ਼'.ord => 'L',
+    '਼'.ord => 'æ',
+    'ੑ'.ord => '@',
+    'ੵ'.ord => "\u00b4", # acute accent (´)
+    'ਃ'.ord => 'Ú', # capital u-acute letter
+    "\u0a13".ord => 'E', # ਓ
+    "\u0a06".ord => 'Aw',  # ਆ
+    "\u0a07".ord => 'ei',  # ਇ
+    "\u0a08".ord => 'eI',  # ਈ
+    "\u0a09".ord => 'au',  # ਉ
+    "\u0a0a".ord => 'aU',  # ਊ
+    "\u0a0f".ord => 'ey',  # ਏ
+    "\u0a10".ord => 'AY',  # ਐ
+    "\u0a14".ord => 'AO',  # ਔ
+    'ਾ'.ord => 'w',
+    'ਿ'.ord => 'i',
+    'ੀ'.ord => 'I',
+    'ੁ'.ord => 'u',
+    'ੂ'.ord => 'U',
+    'ੇ'.ord => 'y',
+    'ੈ'.ord => 'Y',
+    'ੋ'.ord => 'o',
+    'ੌ'.ord => 'O',
+    'ੰ'.ord => 'M',
+    'ਂ'.ord => 'N',
+    'ੱ'.ord => '~',
+    '।'.ord => '[',
+    '॥'.ord => ']',
+    '੦'.ord => '0',
+    '੧'.ord => '1',
+    '੨'.ord => '2',
+    '੩'.ord => '3',
+    '੪'.ord => '4',
+    '੫'.ord => '5',
+    '੬'.ord => '6',
+    '੭'.ord => '7',
+    '੮'.ord => '8',
+    '੯'.ord => '9',
+    'ੴ'.ord => '<>',
+    '☬'.ord => 'Ç'
+  }.freeze
+
+  ASCII_REPLACEMENTS = {
+    '੍ਯ' => 'Î',  # half-yayya
+    '꠳ਯ' => 'Î',  # sant lipi variation
+    '꠴ਯ' => 'ï',  # open-top yayya
+    '꠵ਯ' => 'î',  # open-top half-yayya
+    '੍ਰ' => 'R',
+    '੍ਵ' => 'Í',  # capital i-acute letter
+    '੍ਹ' => 'H',
+    '੍ਚ' => 'ç',  # c-cedilla letter
+    '੍ਟ' => '†',  # dagger symbol
+    '੍ਤ' => 'œ',
+    '੍ਨ' => "\u02dc" # small tilde (˜)
+  }.freeze
+
+  # Warnings
+  ABOVE_VOWEL_MARKS = ['ੇ', 'ੈ', 'ੋ', 'ੌ'].join
+  BELOW_VOWEL_MARKS = ['ੁ', 'ੂ'].join
+  def self.check_warnings(string)
+    warnings = []
+
+    warnings << 'Incorrect vowel syntax (above vowel)' if string.match?(/ਾ[#{ABOVE_VOWEL_MARKS}]ਾ[#{ABOVE_VOWEL_MARKS}]/)
+
+    warnings << 'Incorrect vowel syntax (below vowel)' if string.match?(/ਾ[#{BELOW_VOWEL_MARKS}]ਾ[#{BELOW_VOWEL_MARKS}]/)
+
+    return warnings
+  end
+
+  def self.ascii(string)
+    string = unicode_normalize(string)
+
+    # Perform replacements
+    ASCII_REPLACEMENTS.each do |key, value|
+      string.gsub!(key, value)
+    end
+
+    # Perform translation
+    string = string.chars.map { |c| ASCII_TRANSLATION[c.ord] || c }.join
+
+    # Re-arrange sihari
+    ascii_base_letters = 'AeshkKgG|cCjJ\tTfFxqQdDnpPbBmXrlvVSz^&ZLÎïî'
+    ascii_modifiers = 'æ@´ÚwIuUyYoO`MNRÍHç†œ˜ü¨®µˆW~¤Ï'
+    regex = Regexp.new("([#{ascii_base_letters}][#{ascii_modifiers}]*)i([#{ascii_modifiers}]*)")
+    string.gsub!(regex, 'i\1\2')
+
+    # Fix below-base-letter + u vowel positioning
+    ascii_below_base_letters = 'RÍHç†œ˜'
+    below_vowel_mappings = {
+      'u' => 'ü',
+      'U' => '¨'
+    }
+    below_vowel_mappings.each do |key, value|
+      string.gsub!(/([#{ascii_below_base_letters}][#{ascii_modifiers}]*)#{key}([#{ascii_modifiers}]*)/, "\\1#{value}\\2")
+    end
+
+    # Fix center-stroke + tippi positioning
+    center_stroke_letters = 'nT'
+    string.gsub!(/([#{center_stroke_letters}][#{ascii_modifiers}]*)M([#{ascii_modifiers}]*)/, '\\1µ\\2')
+
+    # Fix positioning of bindi/tippi when it is the only above-base-form
+    ascii_non_above_modifiers = 'æ@´ÚwuURÍHç†œ˜ü¨®Ï'
+    nasalization_mappings = {
+      'N' => 'ˆ',
+      '~' => '`'
+    }
+    nasalization_mappings.each do |key, value|
+      string.gsub!(/([#{ascii_base_letters}][#{ascii_non_above_modifiers}]*)#{key}([#{ascii_non_above_modifiers}]*)/, "\\1#{value}\\2")
+    end
+
+    # Make rendering changes for combos
+    ascii_combo_replacements = {
+      'Iਁ' => 'ˆØI',  # bindi + bihari ligature
+      'IM' => 'µØI',  # tippi + bihari ligature
+      'Iµ' => 'µØI',  # tippi + bihari ligature
+      'kR' => 'k®', # kakka + pair-rara ligature
+      'H¨' => '§',
+      'wN' => 'W',  # addhak positioning
+      'wˆ' => 'W',  # addhak positioning
+      'nUµ' => 'ƒ'
+    }
+    ascii_combo_replacements.each do |key, value|
+      string.gsub!(key, value)
+    end
+    return string
+  end
+end

--- a/lib/ascii.rb
+++ b/lib/ascii.rb
@@ -129,7 +129,7 @@ module GurmukhiUtils
     string.gsub!(regex, 'i\1\2')
 
     # Fix below-base-letter + u vowel positioning
-    ascii_below_base_letters = 'RÍHç†œ˜'
+    ascii_below_base_letters = 'RÍHç†œ˜´@'
     below_vowel_mappings = {
       'u' => 'ü',
       'U' => '¨'

--- a/lib/ascii.rb
+++ b/lib/ascii.rb
@@ -98,18 +98,7 @@ module GurmukhiUtils
     '੍ਨ' => "\u02dc" # small tilde (˜)
   }.freeze
 
-  # Warnings
-  ABOVE_VOWEL_MARKS = ['ੇ', 'ੈ', 'ੋ', 'ੌ'].join
-  BELOW_VOWEL_MARKS = ['ੁ', 'ੂ'].join
-  def self.check_warnings(string)
-    warnings = []
-
-    warnings << 'Incorrect vowel syntax (above vowel)' if string.match?(/ਾ[#{ABOVE_VOWEL_MARKS}]ਾ[#{ABOVE_VOWEL_MARKS}]/)
-
-    warnings << 'Incorrect vowel syntax (below vowel)' if string.match?(/ਾ[#{BELOW_VOWEL_MARKS}]ਾ[#{BELOW_VOWEL_MARKS}]/)
-
-    return warnings
-  end
+  # TODO: Raise warnings  if incorrect vowel syntax
 
   def self.ascii(string)
     string = unicode_normalize(string)

--- a/lib/ascii.rb
+++ b/lib/ascii.rb
@@ -134,6 +134,7 @@ module GurmukhiUtils
       'u' => 'ü',
       'U' => '¨'
     }
+
     below_vowel_mappings.each do |key, value|
       string.gsub!(/([#{ascii_below_base_letters}][#{ascii_modifiers}]*)#{key}([#{ascii_modifiers}]*)/, "\\1#{value}\\2")
     end

--- a/lib/gurmukhi_utils.rb
+++ b/lib/gurmukhi_utils.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative 'unicode'
+require_relative 'ascii'

--- a/spec/ascii_spec.rb
+++ b/spec/ascii_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe GurmukhiUtils do
           'ਖ਼ੁੱਰੋ' => '^u`ro',
           'ਦੋੁਆਲੈ' => 'douAwlY',
           'ਦ੍ਰਿੜੑੀਆ' => 'idRV@IAw',
-          # 'ਕਾਨੑੁ' => 'kwn@ü',
+          'ਕਾਨੑੁ' => 'kwn@ü',
           'ਜਿੰਨੑੀ' => 'ijMn@I',
           'ਓਲੑਾ' => 'El@w',
           'ਸਾਮੑੈ' => 'swm@Y',

--- a/spec/lib/ascii_spec.rb
+++ b/spec/lib/ascii_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'gurmukhi_utils'
+
+RSpec.describe GurmukhiUtils do
+  describe '.ascii' do
+    context 'general cases' do
+      let(:assertions) do
+        {
+          '੧੨੩' => '123',
+          'ੴ ☬ ੴ' => '<> Ç <>',
+          'ਗੁਰੂ' => 'gurU'
+        }
+      end
+
+      it 'converts Gurmukhi Unicode to ASCII' do
+        assertions.each do |key, value|
+          expect(GurmukhiUtils.ascii(key)).to eq(value)
+        end
+      end
+    end
+
+    context 'yayya' do
+      let(:assertions) do
+        {
+          # Yayya
+          'ਯਕੀਂ' => 'XkIN',
+          'ਪ੍ਰਿਯ' => 'ipRX',
+          # ...
+          'ਤ꠳ਯਾਗ꠳ਯੋ' => 'qÎwgÎo',
+          'ਜ꠳ਯੋਂ' => 'jÎoN',
+          # Open-top Yayya
+          'ਨਾਮ꠴ਯ' => 'nwmï',
+          # ...
+          'ਸ꠴ਯਾਮ' => 'sïwm',
+          # Open-top Half-Y
+          'ਦਿਤ꠴ਯਾਦਿਤ꠵ਯ' => 'idqïwidqî',
+          'ਤ੍ਰਸ꠵ਯੋ' => 'qRsîo'
+        }
+      end
+
+      it 'converts Gurmukhi Unicode with yayya cases to ASCII' do
+        assertions.each do |key, value|
+          expect(GurmukhiUtils.ascii(key)).to eq(value)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/ascii_spec.rb
+++ b/spec/lib/ascii_spec.rb
@@ -21,6 +21,42 @@ RSpec.describe GurmukhiUtils do
       end
     end
 
+    context 'diacritics' do
+      let(:assertions) do
+        {
+          'ਕ੍ਰਾਂ' => 'k®W',
+          'ਸ੍ਵਾਂਤਿ' => 'sÍWiq',
+          'ਭ੍ਰਿੰਗ' => 'iBRMg',
+          'ਨ੍ਰਿੱਤੇ' => 'inR`qy',
+          'ਕ੍ਰਿੱਸੰ' => 'ik®`sM',
+          'ਅੰਮ੍ਰਿੱਤ' => 'AMimR`q',
+          'ਥਾਨੵਿੰ' => 'Qwin´µ',
+          'ਕ੍ਰਾਂਤ' => 'k®Wq',
+          'ਕ੍ਰੁੱਧ' => 'k®ü`D',
+          'ਜਿਨ੍ਹੈਂ' => 'ijnHYN',
+          'ਹ੍ਵੈੁਬੋ' => 'hÍYübo',
+          'ਨੂੰ' => 'ƒ',
+          'ਖ਼ੁੱਦ' => '^u`d',
+          'ਫਜ਼ੂੰ' => 'PzUM',
+          'ਕਾਰਮੁੱਲ-ਕੱਰਾਮ' => 'kwrmu`l-k`rwm',
+          'ਫ਼ਰੁੱਖ਼ੇ' => '&ru`^y',
+          'ਖ਼ੁੱਰੋ' => '^u`ro',
+          'ਦੋੁਆਲੈ' => 'douAwlY',
+          'ਦ੍ਰਿੜੑੀਆ' => 'idRV@IAw',
+          # 'ਕਾਨੑੁ' => 'kwn@ü',
+          'ਜਿੰਨੑੀ' => 'ijMn@I',
+          'ਓਲੑਾ' => 'El@w',
+          'ਸਾਮੑੈ' => 'swm@Y',
+          'ਕਤੇਬਹੁਂ' => 'kqybhuˆ'
+        }
+      end
+      it 'handles vowels and other characters like (ਂ), (ੰ), and nukta (਼) to ASCII' do
+        assertions.each do |key, value|
+          expect(GurmukhiUtils.ascii(key)).to eq(value)
+        end
+      end
+    end
+
     context 'yayya' do
       let(:assertions) do
         {
@@ -40,7 +76,7 @@ RSpec.describe GurmukhiUtils do
         }
       end
 
-      it 'converts Gurmukhi Unicode with yayya cases to ASCII' do
+      it 'handle yayya cases to ASCII' do
         assertions.each do |key, value|
           expect(GurmukhiUtils.ascii(key)).to eq(value)
         end


### PR DESCRIPTION
<!-- Please title as if this PR were a single commit to our main branch. -->
<!-- https://docs.shabados.com/community/coding-guidelines#commit-messages -->
<!-- Also don't forget to add any reviewer(s) and link the related issue! -->

### Summary

* We can now run `GurmukhiUtils.ascii(string)`
* Copied the `ascii` code from Python ShabadOS/gurmukhiutils library, [here](https://github.com/shabados/gurmukhiutils/blob/9120f346c54c78a7af8c4a4adee57d29b91f7e4c/gurmukhiutils/ascii.py)
* As well as the specs - rewritten in Ruby (RSpec)

<img width="1010" alt="Screen Shot 2023-04-28 at 9 48 16 PM" src="https://user-images.githubusercontent.com/17516559/235278050-0f0a6a58-45e1-4adf-872a-db0d57232861.png">



### Test
- ✅ all passing :) 


<img width="1026" alt="Screen Shot 2023-04-28 at 9 50 06 PM" src="https://user-images.githubusercontent.com/17516559/235278064-1f0427c0-2f6a-434a-9b98-31bed68f5bac.png">

